### PR TITLE
Use default namespace if no namespace specified

### DIFF
--- a/kubesudo
+++ b/kubesudo
@@ -20,6 +20,11 @@ else
     NAMESPACE=$(kubectl config view --minify --output 'jsonpath={..namespace}')
 fi
 
+if [ -z "$NAMESPACE" ]
+then
+    NAMESPACE=default
+fi
+
 TMPKUBE=$(mktemp)
 
 kubectl config view --flatten --minify > $TMPKUBE


### PR DESCRIPTION
Currently an error is thrown when no namespace is specified for the serviceaccount. However, according to the usage description, the namespace in the parameter is optional.