### PR TITLE
base64 decode - lower case

### DIFF
--- a/kubesudo
+++ b/kubesudo
@@ -35,7 +35,7 @@ SECRET=$(kubectl -n $NAMESPACE get sa $SA -o go-template='{{range .secrets}}{{pr
 TOKEN=$(kubectl -n $NAMESPACE get secret ${SECRET} -o go-template='{{.data.token}}')
 
 kubectl config set-credentials kubesudo:$NAMESPACE:$SA \
-    --token=`echo ${TOKEN} | base64 -D` > /dev/null
+    --token=`echo ${TOKEN} | base64 -d` > /dev/null
 
 kubectl config set-context $(kubectl config current-context) --user=kubesudo:$NAMESPACE:$SA > /dev/null
 


### PR DESCRIPTION
"base64 -D" should be "base64 -d" (at least with base64 from GNU coreutils). Results in "base64: invalid option -- 'D'" otherwise.